### PR TITLE
Seleccion dinamica mapa base

### DIFF
--- a/public_html/visores/ehidrico/config/mapa.json
+++ b/public_html/visores/ehidrico/config/mapa.json
@@ -5,17 +5,29 @@
             "logo": false
         },
         "baseMapLayer": {
-			"url":"http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer",
-			"extent": {
+            "url":"http://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer",
+            "extent": {
                 "xmin": -6364316,
                 "ymin": -4364316,
                 "xmax": -5900316,
                 "ymax": -3364316,
                 "spatialReference": {
-					"wkid":102100
-				}
+                    "wkid":102100
+                }
             }
-		},
+        },
+        "baseMapLayerBackup": {
+            "url": "http://sit.mvotma.gub.uy/arcgis/rest/services/MAPASBASE/MAPA_BASE_2014/MapServer",
+            "extent": {
+                "xmin": -37867.16314808361,
+                "ymin": 5957313.020605681,
+                "xmax": 1220493.68690695,
+                "ymax": 6874864.455708552,
+                "spatialReference": {
+                    "wkid":32721
+                }
+            }
+        },        
         "dynamicLayers": [ 
 			{
                 "url": "http://web.renare.gub.uy/arcgis/rest/services/BASE/Administrativo/MapServer",

--- a/public_html/visores/js/snia/app.js
+++ b/public_html/visores/js/snia/app.js
@@ -49,7 +49,6 @@ snia.app = {
                 arrayUtil.forEach(dynLayers, function (dataLayer, index) {
                     var l = new ArcGISDynamicMapServiceLayer(dataLayer.url, dataLayer.options);
                     if (index === 0) {
-                        //Mapa base
                         mapa.agregarCapa(l);
                     } else {
                         //Agregar capas de forma que las de mas arriba en la conf se muestren en el mapa por encima que las de mas abajo

--- a/public_html/visores/js/snia/app.js
+++ b/public_html/visores/js/snia/app.js
@@ -121,6 +121,19 @@ snia.app = {
                 },
                 baseMapLayer: new ArcGISTiledMapServiceLayer(mapaConfig.mapa.baseMapLayer.url)
             }, "divMapa");
+            
+            //Configurar mapa base de backup si existe
+            if (mapaConfig.mapa.baseMapLayerBackup){
+                mapa.setMapaBaseBackup(
+                    { 
+                        slider: false,
+                        logo: false,
+                        extent: new Extent(mapaConfig.mapa.baseMapLayerBackup.extent)
+                    },
+                    new ArcGISTiledMapServiceLayer(mapaConfig.mapa.baseMapLayerBackup.url)
+                );
+            }
+            
             //tool
             toolConfig = JSON.parse(toolConfigJSON);
             on(mapa, "load", function () {

--- a/public_html/visores/js/snia/widgets/MapaWidget.js
+++ b/public_html/visores/js/snia/widgets/MapaWidget.js
@@ -144,6 +144,16 @@ define([
                 this._restartup();
             }
         },
+        setMapaBaseBackup: function (mapOptionsBackup, baseMapLayerBackup) {
+            //Manejador para el evento de error en mapa base
+            on(this.baseMapLayer, 'error', lang.hitch(this, function () {
+                //Si falla al cargar el mapa base intenta con el de backup
+                this.map.destroy();
+                this.set("map", new Map(this._mapNode, mapOptionsBackup));
+                this.setMapaBase(baseMapLayerBackup);
+                this._init();
+            }));            
+    },
         /* ---------------- */
         /* Funciones Privadas */
         /* ---------------- */

--- a/public_html/visores/js/snia/widgets/MapasBaseWidget.js
+++ b/public_html/visores/js/snia/widgets/MapasBaseWidget.js
@@ -77,8 +77,8 @@ define([
                     //Una celda para cada mapa
                     td = domConstruct.create("td");
                     domConstruct.place(td, tr);
-                   
-//                    //boton para seleccionar mapa
+                                     
+                    //boton para seleccionar mapa
                     boton = new Button({
                         id: item.nombre,
                         disabled: false,
@@ -91,6 +91,12 @@ define([
                     
                     //Cargo el mapa base para el boton
                     item.map = new ArcGISTiledMapServiceLayer(this._mapasBase[index].url);
+                    //Guardo el boton
+                    this._mapasBase[index].boton = boton;
+                    //Listener para remover el boton si el mapa falla
+                    on(item.map, 'error', lang.hitch(this, function () {
+                        this._mapasBase[index].boton.destroy();
+                    }));   
                     //Listener para click en el boton    
                     this.own(on(boton, a11yclick, lang.hitch(this, function () {
                         boton.set('visible', false);


### PR DESCRIPTION
**Seleccion dinamica mapa base**

_Nro de incidencia en Mantis: 0000116_
1.  Si se define un mapa base de backup en la configuración del visor, intenta cargar ese en caso de que el mapa base principal no esté disponible. 
2. Si alguno de los mapas base de la herramienta MapaBase (vectorial, relieve, imagen, ..) no está disponible no se muestra el botón correspondiente.
3. Quedó agregado un mapa base de backup en la configuración de el visor ehidrico.

Ej. de configuración en el mapa.json del visor:
`"baseMapLayerBackup": {
            "url": "http://sit.mvotma.gub.uy/arcgis/rest/services/MAPASBASE/MAPA_BASE_2014/MapServer",
            "extent": {
                "xmin": -37867.16314808361,
                "ymin": 5957313.020605681,
                "xmax": 1220493.68690695,
                "ymax": 6874864.455708552,
                "spatialReference": {
                    "wkid":32721
                }
            }
        },`
