### PR TITLE
Corrección problema al cambiar de mapa

### DIFF
--- a/public_html/visores/js/snia/widgets/MapaWidget.js
+++ b/public_html/visores/js/snia/widgets/MapaWidget.js
@@ -58,11 +58,13 @@ define([
             this.watch("visible", this._visible);
             this.watch("baseMapLayer", this._baseMapLayerChanged);
             this.watch("dibujoEnable", this._dibujoEnabledChanged);
+            this.watch("map", this._mapUpdateImg);
             // classes
             this._css = { };
         },
         postCreate: function () {
             this.inherited(arguments);
+            this._standbyTOC = dom.byId("loadingImg");
             this.set("map", new Map(this._mapNode, this.mapOptions));
             if (this.baseMapLayer) {
                 this.map.addLayer(this.baseMapLayer);
@@ -170,15 +172,7 @@ define([
                 map: this.map,
                 scalebarUnit: "metric"
             });
-            //Rueda de espera 
-            //No se usa el objeto Standby para que no bloquee al usuario mientras espera
-            this._standbyTOC = dom.byId("loadingImg");
-            on(this.map, 'update-start',lang.hitch(this,  function () {
-                domStyle.set(this._standbyTOC, "display", "block");
-            }));
-            on(this.map, 'update-end', lang.hitch(this, function () { 
-                domStyle.set(this._standbyTOC, "display", "none");
-            }));
+            this._mapUpdateImg();
         },
         _dibujoEnabledChanged: function () {
             this.emit("dibujo-enabled-change", this.dibujoEnable);
@@ -243,6 +237,16 @@ define([
                     this._reinit();
                 }));
             }
+        },
+        _mapUpdateImg: function(){
+            //Rueda de espera 
+            //No se usa el objeto Standby para que no bloquee al usuario mientras espera
+            on(this.map, 'update-start',lang.hitch(this,  function () {
+                domStyle.set(this._standbyTOC, "display", "block");
+            }));
+            on(this.map, 'update-end', lang.hitch(this, function () { 
+                domStyle.set(this._standbyTOC, "display", "none");
+            }));
         }
     });
     return widget;


### PR DESCRIPTION
Mergeo una corrección que aún no estaba en master (permite que la ruedita siga funcionando cuando se cambia el mapa base)